### PR TITLE
Optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+perf.data*
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ incremental = false
 codegen-units = 16
 rpath = false
 
+[profile.flamegraph]
+inherits = "release"
+debug = true
+
 [dev-dependencies]
 criterion = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "huff-tree-tap"
-version = "0.1.0"
+version = "0.2.0"
 description = "Huffman Encoder and Decoder Library"
 authors = ["Alexis Lowe <alexis.lowe@chimbosonic.com>"]
 edition = "2021"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
 watch:
 	cargo watch -x fmt -x check -x clippy -x test
+
+flamegraph:
+	cargo flamegraph --profile flamegraph --test tests
+
+bench:
+	cargo bench

--- a/benches/huffman.rs
+++ b/benches/huffman.rs
@@ -28,6 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+// Encode: 650micros Decode: 1.14ms
 criterion_group!(
     name = benches;
     config = Criterion::default().warm_up_time(std::time::Duration::from_secs(10));

--- a/benches/huffman.rs
+++ b/benches/huffman.rs
@@ -28,7 +28,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-// Encode: 650micros Decode: 1.14ms
 criterion_group!(
     name = benches;
     config = Criterion::default().warm_up_time(std::time::Duration::from_secs(10));

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,10 +1,52 @@
 use crate::error::{HuffmanError, Result};
 
-pub type ByteString = String;
+pub type Bit = u8;
 
-pub type PaddedBits = String;
+pub type BitVec = Vec<Bit>;
 
-pub type UnPaddedBits = String;
+pub trait ToFromChar {
+    fn to_char(&self) -> char;
+    fn from_char(c: char) -> Self;
+}
+
+impl ToFromChar for Bit {
+    fn to_char(&self) -> char {
+        match self {
+            0 => '0',
+            1 => '1',
+            _ => panic!("Invalid bit"),
+        }
+    }
+
+    fn from_char(c: char) -> Self {
+        match c {
+            '0' => 0,
+            '1' => 1,
+            _ => panic!("Invalid bit"),
+        }
+    }
+}
+
+pub trait BitVector {
+    fn to_string(&self) -> String;
+    fn from_string(s: &str) -> BitVec;
+}
+
+impl BitVector for BitVec {
+    fn to_string(&self) -> String {
+        self.iter().map(|bit| bit.to_char()).collect()
+    }
+
+    fn from_string(s: &str) -> BitVec {
+        s.chars().map(Bit::from_char).collect()
+    }
+}
+
+pub type Byte = BitVec;
+
+pub type PaddedBits = BitVec;
+
+pub type UnPaddedBits = BitVec;
 
 pub trait UnPadded {
     fn pad(&self) -> PaddedBits;
@@ -14,9 +56,9 @@ trait ToByte {
     fn to_byte(&self) -> Result<u8>;
 }
 
-impl ToByte for ByteString {
+impl ToByte for Byte {
     fn to_byte(&self) -> Result<u8> {
-        u8::from_str_radix(self, 2).map_err(|_| {
+        u8::from_str_radix(&self.to_string(), 2).map_err(|_| {
             HuffmanError::ByteStringConversionError("Binary String passed contained a non-bit 0/1")
         })
     }
@@ -30,40 +72,42 @@ pub trait Padded {
 
 impl Padded for PaddedBits {
     fn unpad(&self) -> UnPaddedBits {
-        let mut data: String = String::new();
-        let mut temp_padded_byte: String = String::new();
+        let mut data = UnPaddedBits::new();
+        let mut temp_padded_byte = PaddedBits::new();
 
-        for bit in self.chars() {
+        for bit in self {
             if temp_padded_byte.len() > 7 {
                 let (_, byte) = temp_padded_byte.split_at(1);
-                data += byte;
-                temp_padded_byte = String::new();
+                data.extend_from_slice(byte);
+                temp_padded_byte = PaddedBits::new();
             }
-            temp_padded_byte.push(bit);
+            temp_padded_byte.push(*bit);
         }
         let (_, byte) = temp_padded_byte.split_at(1);
-        data += byte;
+        data.extend_from_slice(byte);
         data
     }
 
     fn from_vec_u8(u8_vec: &[u8]) -> PaddedBits {
         let mut bin_string = PaddedBits::new();
         for byte in u8_vec {
-            bin_string.push_str(format!("{:b}", byte).as_str());
+            let byte = format!("{:b}", byte);
+            let byte = BitVec::from_string(byte.as_str());
+            bin_string.extend_from_slice(&byte);
         }
         bin_string
     }
 
     fn to_vec_u8(&self) -> Result<Vec<u8>> {
-        let mut temp_byte = ByteString::new();
+        let mut temp_byte = Byte::new();
         let mut u8_vec: Vec<u8> = Vec::new();
 
-        for bit in self.chars() {
+        for bit in self {
             if temp_byte.len() == 8 {
                 u8_vec.push(temp_byte.to_byte()?);
-                temp_byte = String::new();
+                temp_byte = Byte::new();
             }
-            temp_byte.push(bit);
+            temp_byte.push(*bit);
         }
         u8_vec.push(temp_byte.to_byte()?);
         Ok(u8_vec)
@@ -72,18 +116,19 @@ impl Padded for PaddedBits {
 
 impl UnPadded for UnPaddedBits {
     fn pad(&self) -> PaddedBits {
-        let mut padded_encoded_data = PaddedBits::new();
-        let mut temp_padded_byte: String = String::from("1");
+        let mut padded_bits = PaddedBits::new();
+        let mut temp_padded_byte = Byte::new();
+        temp_padded_byte.push(1);
 
-        for bit in self.chars() {
+        for bit in self {
             if temp_padded_byte.len() > 7 {
-                padded_encoded_data.push_str(&temp_padded_byte);
-                temp_padded_byte = String::from("1");
+                padded_bits.append(&mut temp_padded_byte);
+                temp_padded_byte.push(1);
             }
-            temp_padded_byte.push(bit);
+            temp_padded_byte.push(*bit);
         }
-        padded_encoded_data.push_str(&temp_padded_byte);
-        padded_encoded_data
+        padded_bits.append(&mut temp_padded_byte);
+        padded_bits
     }
 }
 
@@ -93,9 +138,9 @@ mod tests {
 
     #[test]
     fn test_unpadded_bits_pad() {
-        let input_data = UnPaddedBits::from("1011100101010000010100000110100101110101001010011011111000111001111011101001001010111010111111100001100");
+        let input_data = UnPaddedBits::from_string("1011100101010000010100000110100101110101001010011011111000111001111011101001001010111010111111100001100");
 
-        let expected_data = PaddedBits::from("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
+        let expected_data = PaddedBits::from_string("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
 
         let test_output = input_data.pad();
 
@@ -104,9 +149,9 @@ mod tests {
 
     #[test]
     fn test_padded_bits_unpad() {
-        let input_data = PaddedBits::from("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
+        let input_data = PaddedBits::from_string("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
 
-        let expected_data = UnPaddedBits::from("1011100101010000010100000110100101110101001010011011111000111001111011101001001010111010111111100001100");
+        let expected_data = BitVec::from_string("1011100101010000010100000110100101110101001010011011111000111001111011101001001010111010111111100001100");
 
         let test_output = input_data.unpad();
 
@@ -115,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_padded_bits_to_u8_vec() {
-        let input_data = PaddedBits::from("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
+        let input_data = PaddedBits::from_string("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
 
         let expected_data: Vec<u8> = vec![
             220, 212, 138, 134, 203, 212, 211, 190, 156, 251, 210, 171, 215, 248, 44,
@@ -132,7 +177,7 @@ mod tests {
             220, 212, 138, 134, 203, 212, 211, 190, 156, 251, 210, 171, 215, 248, 44,
         ];
 
-        let expected_data = PaddedBits::from("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
+        let expected_data = PaddedBits::from_string("1101110011010100100010101000011011001011110101001101001110111110100111001111101111010010101010111101011111111000101100");
 
         let test_output = PaddedBits::from_vec_u8(&input_data);
 

--- a/src/encoding_map.rs
+++ b/src/encoding_map.rs
@@ -13,10 +13,26 @@ pub struct EncodingMap {
     inverse_map: InverseMap,
 }
 
+pub type Code = String;
+
+trait Codeable {
+    fn new_code() -> Code;
+    fn extend_code(&self, bit: char) -> Code;
+}
+impl Codeable for Code {
+    fn new_code() -> Code {
+        String::new()
+    }
+
+    fn extend_code(&self, bit: char) -> Code {
+        format!("{}{}", self, bit)
+    }
+}
+
 impl EncodingMap {
     pub fn new(huffman_tree: &Node) -> Result<Self> {
         let mut map = Map::new();
-        Self::build_encoding_map(huffman_tree, &mut map, "");
+        Self::build_encoding_map(huffman_tree, &mut map, &Code::new_code());
 
         let inverse_map = map.iter().map(|(k, v)| (v.clone(), *k)).collect();
 
@@ -41,17 +57,17 @@ impl EncodingMap {
     }
 
     /// Creates a Hash Map of the encoding of every u8 within a given Huffman Tree. Left node edges are 0s and right node edges are 1s
-    fn build_encoding_map(node: &Node, map: &mut Map, code: &str) {
+    fn build_encoding_map(node: &Node, map: &mut Map, code: &Code) {
         match node.value {
             Some(value) => {
                 map.insert(value, code.to_string());
             }
             None => {
                 if let Some(left) = &node.left {
-                    Self::build_encoding_map(left, map, &format!("{}{}", code, "0"));
+                    Self::build_encoding_map(left, map, &code.extend_code('0'));
                 }
                 if let Some(right) = &node.right {
-                    Self::build_encoding_map(right, map, &format!("{}{}", code, "1"));
+                    Self::build_encoding_map(right, map, &code.extend_code('1'));
                 }
             }
         }

--- a/src/encoding_map.rs
+++ b/src/encoding_map.rs
@@ -13,19 +13,56 @@ pub struct EncodingMap {
     inverse_map: InverseMap,
 }
 
-pub type Code = String;
+pub type Bit = u8;
+
+pub type Code = Vec<Bit>;
+
+
+trait ToFromChar {
+    fn to_char(&self) -> char;
+    fn from_char(c: char) -> Self;
+}
+
+impl ToFromChar for Bit {
+    fn to_char(&self) -> char {
+        match self {
+            0 => '0',
+            1 => '1',
+            _ => panic!("Invalid bit"),
+        }
+    }
+
+    fn from_char(c: char) -> Self {
+        match c {
+            '0' => 0,
+            '1' => 1,
+            _ => panic!("Invalid bit"),
+        }
+    }
+}
 
 trait Codeable {
     fn new_code() -> Code;
     fn extend_code(&self, bit: char) -> Code;
+    fn to_string(&self) -> String;
 }
 impl Codeable for Code {
     fn new_code() -> Code {
-        String::new()
+        Vec::<u8>::new()
+    }
+
+    fn to_string(&self) -> String {
+        self.iter()
+            .map(|bit| {
+                bit.to_char()
+            })
+            .collect()
     }
 
     fn extend_code(&self, bit: char) -> Code {
-        format!("{}{}", self, bit)
+        let mut code = self.clone();
+        code.push(Bit::from_char(bit));
+        code
     }
 }
 
@@ -60,7 +97,7 @@ impl EncodingMap {
     fn build_encoding_map(node: &Node, map: &mut Map, code: &Code) {
         match node.value {
             Some(value) => {
-                map.insert(value, code.to_string());
+                map.insert(value, Codeable::to_string(code));
             }
             None => {
                 if let Some(left) = &node.left {

--- a/src/encoding_map.rs
+++ b/src/encoding_map.rs
@@ -62,6 +62,22 @@ impl EncodingMap {
         self.map.get(key)
     }
 
+    pub fn get_shortest_code(&self) -> usize {
+        if let Some(el) = self.inverse_map.keys().min_by_key(|v| v.len()) {
+            el.len()
+        } else {
+            0
+        }
+    }
+
+    pub fn get_longest_code(&self) -> usize {
+        if let Some(el) = self.inverse_map.keys().max_by_key(|v| v.len()) {
+            el.len()
+        } else {
+            0
+        }
+    }
+
     pub fn get_inverse(&self, key: &BitVec) -> Option<&u8> {
         self.inverse_map.get(key)
     }
@@ -123,7 +139,7 @@ mod tests {
 
         // Create a encoding map from the tree this we can test better
         let test_output = EncodingMap::new(&huffman_tree).unwrap();
-
+        assert_eq!(test_output.get_shortest_code(), 2);
         assert_eq!(expected_data, test_output);
     }
 }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -84,13 +84,18 @@ impl HuffmanData {
     }
 
     fn huffman_decode(encoded_data: &UnPaddedBits, encoding_map: &EncodingMap) -> Vec<u8> {
-        let mut data: Vec<u8> = Vec::new();
-        let mut temp_code = BitVec::new();
+        let mut data: Vec<u8> = Vec::with_capacity(encoded_data.len());
+        let mut code = BitVec::with_capacity(encoding_map.get_longest_code());
+        let min_len = encoding_map.get_shortest_code();
 
         for code_bit in encoded_data {
-            temp_code.push(*code_bit);
-            if let Some(&byte) = encoding_map.get_inverse(&temp_code) {
-                temp_code = BitVec::new();
+            code.push(*code_bit);
+            if code.len() < min_len {
+                continue;
+            }
+
+            if let Some(&byte) = encoding_map.get_inverse(&code) {
+                code.clear();
                 data.push(byte);
             }
         }

--- a/src/huffman_tree.rs
+++ b/src/huffman_tree.rs
@@ -34,7 +34,7 @@ impl Node {
 /// We sort the frequency list alphabetically then we sort it by frequency to give us consitancy in the tree we generate
 pub fn build(frequency_map: &FrequencyMap) -> Result<Node> {
     //Create a Vector of Nodes containing each u8 and their frequency
-    let mut freq_list: Vec<Node> = Vec::new();
+    let mut freq_list: Vec<Node> = Vec::with_capacity(frequency_map.len());
     for (&data, &freq) in frequency_map {
         freq_list.push(Node::new_leaf(freq, Some(data)));
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -102,7 +102,6 @@ fn test_bench() {
     assert_eq!(encoded_data.decode().unwrap(), unencoded_data);
 }
 
-
 #[test]
 fn test_large_payload_10_000_000() {
     let mut unencoded_data = Vec::<u8>::with_capacity(640_000_000);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -101,3 +101,25 @@ fn test_bench() {
 
     assert_eq!(encoded_data.decode().unwrap(), unencoded_data);
 }
+
+
+#[test]
+fn test_large_payload_10_000_000() {
+    let mut unencoded_data = Vec::<u8>::with_capacity(640_000_000);
+    for _ in 0..10_000_000 {
+        unencoded_data.append(&mut vec![b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h']);
+    }
+    let encoded_data = HuffmanData::new(&unencoded_data).unwrap();
+    let decoded_data = encoded_data.decode().unwrap();
+
+    assert_eq!(
+        encoded_data.stats,
+        EncodingStats {
+            data_size: 640000000.0,
+            encoded_size: 274285730.0,
+            ratio: 57.142853,
+        }
+    );
+
+    assert_eq!(decoded_data, unencoded_data);
+}


### PR DESCRIPTION
## Before

```
Huffman/huffman_encode  time:   [648.36 µs 666.83 µs 686.34 µs]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
Benchmarking Huffman/huffman_decode: Warming up for 10.000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.5s, enable flat sampling, or reduce sample count to 60.
Huffman/huffman_decode  time:   [1.0349 ms 1.0611 ms 1.0909 ms]
Found 18 outliers among 100 measurements (18.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  12 (12.00%) high severe
```

## After
```
Huffman/huffman_encode  time:   [406.26 µs 414.72 µs 423.78 µs]
                        change: [-39.115% -37.313% -35.510%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe
Huffman/huffman_decode  time:   [392.79 µs 397.60 µs 404.15 µs]
                        change: [-62.323% -61.680% -61.009%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
```